### PR TITLE
change screenshot-tag-colorspace default value to `yes`

### DIFF
--- a/src/MpvNet.Windows/Resources/editor_conf.txt
+++ b/src/MpvNet.Windows/Resources/editor_conf.txt
@@ -747,7 +747,7 @@ option = png
 
 name = screenshot-tag-colorspace
 file = mpv
-default = no
+default = yes
 directory = Video/Screenshot
 help = Tag screenshots with the appropriate colorspace. Note that not all formats are supported.
 option = yes


### PR DESCRIPTION
From mpv 0.36.0, default value of --screenshot-tag-colorspace changed from `no` to `yes`
https://github.com/mpv-player/mpv/blob/19a37f625fcd502acea42b4f27029c8be724d40c/DOCS/interface-changes.rst?plain=1#L163