### PR TITLE
Fix long path loading issue (#735)

### DIFF
--- a/src/MpvNet/Player.cs
+++ b/src/MpvNet/Player.cs
@@ -477,8 +477,18 @@ public class MainPlayer : MpvClient
         if (!path.Contains(':') && !path.StartsWith("\\\\") && File.Exists(path))
             path = System.IO.Path.GetFullPath(path);
 
+        path = System.IO.Path.GetFullPath(path);
+
+        if (path.Length >= 260 &&
+            !path.StartsWith(@"\\?\") &&
+            System.Text.RegularExpressions.Regex.IsMatch(path, @"^[a-zA-Z]:\\"))
+        {
+            path = @"\\?\" + path;
+        }
+
         return path;
     }
+
 
     public void LoadISO(string path)
     {


### PR DESCRIPTION
Fix: Support for long file paths on Windows (#735)
This fixes the issue where mpvnet.exe wouldn’t open files with really long paths when launched from the command line or another program.

I updated the ConvertFilePath method to add the \\?\ prefix to long Windows paths. That way, it can handle paths over 260 characters just like mpv.exe does.

Tested with short and long filenames and everything seems to work fine. Let me know if I should change anything. This is my first contribution so sorry if I messed up something.